### PR TITLE
Add plain alsa-lib dep so that global pin is picked up

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- 1.2.7
 c_compiler:
 - gcc
 c_compiler_version:
@@ -14,9 +16,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-pin_run_as_build:
-  readline:
-    max_pin: x
 readline:
 - '8'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+alsa_lib:
+- 1.2.7
 c_compiler:
 - gcc
 c_compiler_version:
@@ -18,9 +20,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
-pin_run_as_build:
-  readline:
-    max_pin: x
 readline:
 - '8'
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- 1.2.7
 c_compiler:
 - gcc
 c_compiler_version:
@@ -14,9 +16,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-pin_run_as_build:
-  readline:
-    max_pin: x
 readline:
 - '8'
 target_platform:

--- a/.ci_support/migrations/alsa_lib127.yaml
+++ b/.ci_support/migrations/alsa_lib127.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-alsa_lib:
-- 1.2.7
-migrator_ts: 1654235946.1965144

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ocefpaf @scopatz
+* @ocefpaf @ryanvolz @scopatz

--- a/README.md
+++ b/README.md
@@ -177,5 +177,6 @@ Feedstock Maintainers
 =====================
 
 * [@ocefpaf](https://github.com/ocefpaf/)
+* [@ryanvolz](https://github.com/ryanvolz/)
 * [@scopatz](https://github.com/scopatz/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - common-jackapi.cpp.patch
 
 build:
-  number: 1003
+  number: 1004
   skip: True  # [win or osx]
   run_exports:
     - {{ pin_subpackage('jack', max_pin='x.x') }}
@@ -27,6 +27,7 @@ requirements:
     - pkg-config
   host:
     - libdb
+    - alsa-lib
     - alsa-lib >=1.0.18
     - libsndfile
     - readline

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,3 +50,4 @@ extra:
   recipe-maintainers:
     - ocefpaf
     - scopatz
+    - ryanvolz


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
- Also this happens to rebuild against `libsndfile=1.1`, which is helpful to me while waiting on https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3526.
- Also adding myself as a maintainer so I can help out as someone who is already helping to maintain a few of these sound system packages.